### PR TITLE
Pass the whole form object to the steps

### DIFF
--- a/server/forms/interfaces/index.ts
+++ b/server/forms/interfaces/index.ts
@@ -17,5 +17,5 @@ export type ReferralApplicationBody = Partial<ApType & ReferralReason & OpdPathw
 export type ReferralApplicationRequest = Request<
   ReferralApplicationParams,
   Record<string, unknown>,
-  ReferralApplicationBody
+  Record<string, unknown>
 >

--- a/server/forms/referral-application.form.ts
+++ b/server/forms/referral-application.form.ts
@@ -62,7 +62,7 @@ export class ReferralApplication {
     try {
       const CurrentStep = stepList[this.stepName]
 
-      return new CurrentStep(this.request.body, this.sessionData)
+      return new CurrentStep(this)
     } catch (err) {
       throw new UnknownStepError()
     }

--- a/server/forms/steps/ap-type.step.spec.ts
+++ b/server/forms/steps/ap-type.step.spec.ts
@@ -1,13 +1,22 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import { ReferralApplication } from '../referral-application.form'
 import ApTypeStep from './ap-type.step'
 
 describe('ApTypeStep', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true with no errors if the body are valid', async () => {
-      const body = {
+      form.request.body = {
         type: 'standard',
       }
 
-      const step = new ApTypeStep(body, {})
+      const step = new ApTypeStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -15,8 +24,8 @@ describe('ApTypeStep', () => {
     })
 
     it('should return false with errors if the body are empty', async () => {
-      const body = {}
-      const step = new ApTypeStep(body, {})
+      form.request.body = {}
+      const step = new ApTypeStep(form)
 
       const valid = await step.valid()
 
@@ -28,21 +37,27 @@ describe('ApTypeStep', () => {
 
   describe('nextStep', () => {
     it('should return undefined for a type of `standard`', () => {
-      const step = new ApTypeStep({ type: 'standard' }, {})
+      form.request.body = { type: 'standard' }
+
+      const step = new ApTypeStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual(undefined)
     })
 
     it('should return `opd-pathway` for a type of `pipe`', () => {
-      const step = new ApTypeStep({ type: 'pipe' }, {})
+      form.request.body = { type: 'pipe' }
+
+      const step = new ApTypeStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual('opd-pathway')
     })
 
     it('should return `esap-reasons` for a type of `esap`', () => {
-      const step = new ApTypeStep({ type: 'esap' }, {})
+      form.request.body = { type: 'esap' }
+
+      const step = new ApTypeStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual('esap-reasons')
@@ -51,7 +66,7 @@ describe('ApTypeStep', () => {
 
   describe('previousStep()', () => {
     it('should return `referral-reason`', () => {
-      const step = new ApTypeStep({}, {})
+      const step = new ApTypeStep(form)
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual('referral-reason')
@@ -60,14 +75,16 @@ describe('ApTypeStep', () => {
 
   describe('allowedToAccess', () => {
     it('it should return false when the reason is undefined', () => {
-      const step = new ApTypeStep({}, {})
+      const step = new ApTypeStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return true when the reason is defined', () => {
-      const step = new ApTypeStep({}, { reason: 'likely' })
+      form.sessionData = { reason: 'likely' }
+
+      const step = new ApTypeStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)

--- a/server/forms/steps/cctv.step.spec.ts
+++ b/server/forms/steps/cctv.step.spec.ts
@@ -1,16 +1,25 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import { ReferralApplication } from '../referral-application.form'
 import CCTVStep from './cctv.step'
 
 describe('CCTVStep', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true with no errors if the params are valid', async () => {
-      const body = {
+      form.request.body = {
         cctvReasons: ['appearance', 'networks'],
         cctvAgencyRequest: 'yes',
         cctvAgency: 'some agency',
         cctvSupportingInformation: 'supporting',
       }
 
-      const step = new CCTVStep(body, {})
+      const step = new CCTVStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -18,8 +27,8 @@ describe('CCTVStep', () => {
     })
 
     it('should return false with errors if the params are empty', async () => {
-      const body = {}
-      const step = new CCTVStep(body, {})
+      form.request.body = {}
+      const step = new CCTVStep(form)
 
       const valid = await step.valid()
 
@@ -35,12 +44,12 @@ describe('CCTVStep', () => {
     })
 
     it('should return false with errors if agency request `yes` and agency is blank', async () => {
-      const body = {
+      form.request.body = {
         cctvReasons: ['appearance', 'networks'],
         cctvAgencyRequest: 'yes',
       }
 
-      const step = new CCTVStep(body, {})
+      const step = new CCTVStep(form)
 
       const valid = await step.valid()
 
@@ -55,7 +64,7 @@ describe('CCTVStep', () => {
 
   describe('nextStep', () => {
     it('should return undefined', () => {
-      const step = new CCTVStep({}, {})
+      const step = new CCTVStep(form)
 
       const nextStep = step.nextStep()
 
@@ -65,7 +74,9 @@ describe('CCTVStep', () => {
 
   describe('previousStep', () => {
     it('should return `room-searches` if the reasons for an esap included `secreting`', () => {
-      const step = new CCTVStep({}, { reasons: ['secreting'] })
+      form.sessionData = { reasons: ['secreting'] }
+
+      const step = new CCTVStep(form)
 
       const previousStep = step.previousStep()
 
@@ -73,7 +84,9 @@ describe('CCTVStep', () => {
     })
 
     it('should return `room-searches` if the reasons for an esap did not include `secreting`', () => {
-      const step = new CCTVStep({}, { reasons: ['cctv'] })
+      form.sessionData = { reasons: ['cctv'] }
+
+      const step = new CCTVStep(form)
 
       const previousStep = step.previousStep()
 
@@ -83,21 +96,25 @@ describe('CCTVStep', () => {
 
   describe('allowedToAccess', () => {
     it('it should return true if the cctv question was previously selected', () => {
-      const step = new CCTVStep({}, { reasons: ['cctv'] })
+      form.sessionData = { reasons: ['cctv'] }
+
+      const step = new CCTVStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)
     })
 
     it('it should return false if the cctv question was not previously selected', () => {
-      const step = new CCTVStep({}, { reasons: ['secreting'] })
+      form.sessionData = { reasons: ['secreting'] }
+
+      const step = new CCTVStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return false if the session is blank', () => {
-      const step = new CCTVStep({}, {})
+      const step = new CCTVStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)

--- a/server/forms/steps/esap-reasons.step.spec.ts
+++ b/server/forms/steps/esap-reasons.step.spec.ts
@@ -1,13 +1,22 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import { ReferralApplication } from '../referral-application.form'
 import EsapReasonsStep from './esap-reasons.step'
 
 describe('ApTypeStep', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true with no errors if the body are valid', async () => {
-      const body = {
+      form.request.body = {
         reasons: ['secreting'],
       }
 
-      const step = new EsapReasonsStep(body, {})
+      const step = new EsapReasonsStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -15,11 +24,11 @@ describe('ApTypeStep', () => {
     })
 
     it('should return true with no errors if the body are invalid', async () => {
-      const body = {
+      form.request.body = {
         reasons: [] as Array<string>,
       }
 
-      const step = new EsapReasonsStep(body, {})
+      const step = new EsapReasonsStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -27,8 +36,8 @@ describe('ApTypeStep', () => {
     })
 
     it('should return false with errors if the body are empty', async () => {
-      const body = {}
-      const step = new EsapReasonsStep(body, {})
+      form.request.body = {}
+      const step = new EsapReasonsStep(form)
 
       const valid = await step.valid()
 
@@ -40,33 +49,33 @@ describe('ApTypeStep', () => {
 
   describe('nextStep', () => {
     it('should return `room-searches` when `secreting` is in the reasons', () => {
-      const body = {
+      form.request.body = {
         reasons: ['secreting'],
       }
 
-      const step = new EsapReasonsStep(body, {})
+      const step = new EsapReasonsStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual('room-searches')
     })
 
     it('should return `cctv` when `cctv` is in the reasons, but not `secreting`', () => {
-      const body = {
+      form.request.body = {
         reasons: ['cctv'],
       }
 
-      const step = new EsapReasonsStep(body, {})
+      const step = new EsapReasonsStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual('cctv')
     })
 
     it('should return `room-searches` when `cctv` and `secreting` are in the reasons', () => {
-      const body = {
+      form.request.body = {
         reasons: ['cctv', 'secreting'],
       }
 
-      const step = new EsapReasonsStep(body, {})
+      const step = new EsapReasonsStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual('room-searches')
@@ -75,7 +84,7 @@ describe('ApTypeStep', () => {
 
   describe('previousStep', () => {
     it('should return `type-of-ap`', () => {
-      const step = new EsapReasonsStep({}, {})
+      const step = new EsapReasonsStep(form)
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual('type-of-ap')
@@ -84,21 +93,25 @@ describe('ApTypeStep', () => {
 
   describe('allowedToAccess', () => {
     it('it should return false when the type is undefined', () => {
-      const step = new EsapReasonsStep({}, {})
+      const step = new EsapReasonsStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return true when the type is esap', () => {
-      const step = new EsapReasonsStep({}, { type: 'esap' })
+      form.sessionData = { type: 'esap' }
+
+      const step = new EsapReasonsStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)
     })
 
     it('it should return false when the type is standard', () => {
-      const step = new EsapReasonsStep({}, { type: 'standard' })
+      form.sessionData = { type: 'standard' }
+
+      const step = new EsapReasonsStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)

--- a/server/forms/steps/not-eligible.step.spec.ts
+++ b/server/forms/steps/not-eligible.step.spec.ts
@@ -1,9 +1,18 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import { ReferralApplication } from '../referral-application.form'
 import NotEligibleStep from './not-eligible.step'
 
 describe('NotEligibleSep', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true', async () => {
-      const step = new NotEligibleStep({}, {})
+      const step = new NotEligibleStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -13,7 +22,7 @@ describe('NotEligibleSep', () => {
 
   describe('nextStep', () => {
     it('should return undefined', () => {
-      const step = new NotEligibleStep({}, {})
+      const step = new NotEligibleStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual(undefined)
@@ -22,7 +31,7 @@ describe('NotEligibleSep', () => {
 
   describe('previousStep', () => {
     it('should return `referral-reason`', () => {
-      const step = new NotEligibleStep({}, {})
+      const step = new NotEligibleStep(form)
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual('referral-reason')
@@ -31,14 +40,16 @@ describe('NotEligibleSep', () => {
 
   describe('allowedToAccess', () => {
     it('it should return false when the reason is undefined', () => {
-      const step = new NotEligibleStep({}, {})
+      const step = new NotEligibleStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return true when the reason is defined', () => {
-      const step = new NotEligibleStep({}, { reason: 'likely' })
+      form.sessionData = { reason: 'likely' }
+
+      const step = new NotEligibleStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)

--- a/server/forms/steps/opd-pathway.step.spec.ts
+++ b/server/forms/steps/opd-pathway.step.spec.ts
@@ -1,13 +1,22 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
+import { ReferralApplication } from '../referral-application.form'
 import OpdPathwayStep from './opd-pathway.step'
 
 describe('OpdPathwayStep', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true if the screening has NOT taken place', async () => {
-      const body = {
+      form.request.body = {
         is_opd_pathway_screened: 'no',
       }
 
-      const step = new OpdPathwayStep(body, {})
+      const step = new OpdPathwayStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -15,12 +24,12 @@ describe('OpdPathwayStep', () => {
     })
 
     it('should return true if the screening HAS taken place and a date is supplied', async () => {
-      const body = {
+      form.request.body = {
         is_opd_pathway_screened: 'yes',
         lastOpdDate: '2021-11-17',
       }
 
-      const step = new OpdPathwayStep(body, {})
+      const step = new OpdPathwayStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -28,12 +37,12 @@ describe('OpdPathwayStep', () => {
     })
 
     it('should return false if the screening HAS taken place and a date is NOT supplied', async () => {
-      const body = {
+      form.request.body = {
         is_opd_pathway_screened: 'yes',
         lastOpdDate: '--',
       }
 
-      const step = new OpdPathwayStep(body, {})
+      const step = new OpdPathwayStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(false)
@@ -42,12 +51,12 @@ describe('OpdPathwayStep', () => {
     })
 
     it('should return false if the screening HAS taken place and a date is invalid', async () => {
-      const body = {
+      form.request.body = {
         is_opd_pathway_screened: 'yes',
         lastOpdDate: '33-23-2022',
       }
 
-      const step = new OpdPathwayStep(body, {})
+      const step = new OpdPathwayStep(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(false)
@@ -56,8 +65,8 @@ describe('OpdPathwayStep', () => {
     })
 
     it('should return false with errors if the body are empty', async () => {
-      const body = {}
-      const step = new OpdPathwayStep(body, {})
+      form.request.body = {}
+      const step = new OpdPathwayStep(form)
 
       const valid = await step.valid()
 
@@ -71,7 +80,9 @@ describe('OpdPathwayStep', () => {
 
   describe('nextStep', () => {
     it('should return undefined', () => {
-      const step = new OpdPathwayStep({ is_opd_pathway_screened: 'yes' }, {})
+      form.request.body = { is_opd_pathway_screened: 'yes' }
+
+      const step = new OpdPathwayStep(form)
       const nextStep = step.nextStep()
 
       expect(nextStep).toEqual(undefined)
@@ -80,7 +91,7 @@ describe('OpdPathwayStep', () => {
 
   describe('previousStep()', () => {
     it('should return `type-of-ap`', () => {
-      const step = new OpdPathwayStep({}, {})
+      const step = new OpdPathwayStep(form)
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual('type-of-ap')
@@ -89,21 +100,25 @@ describe('OpdPathwayStep', () => {
 
   describe('allowedToAccess', () => {
     it('it should return false when the type-of-ap is undefined', () => {
-      const step = new OpdPathwayStep({}, {})
+      const step = new OpdPathwayStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return false when the type-of-ap is not "pipe"', () => {
-      const step = new OpdPathwayStep({}, { type: 'esap' })
+      form.sessionData = { type: 'esap' }
+
+      const step = new OpdPathwayStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return true when the type-of-ap is defined', () => {
-      const step = new OpdPathwayStep({}, { type: 'pipe' })
+      form.sessionData = { type: 'pipe' }
+
+      const step = new OpdPathwayStep(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)

--- a/server/forms/steps/referral-reason.step.spec.ts
+++ b/server/forms/steps/referral-reason.step.spec.ts
@@ -1,13 +1,22 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
 import ReferralReason from './referral-reason.step'
+import { ReferralApplication } from '../referral-application.form'
 
 describe('ReferralReason', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true with no errors if the params are valid', async () => {
-      const body = {
+      form.request.body = {
         reason: 'likely' as const,
       }
 
-      const step = new ReferralReason(body, {})
+      const step = new ReferralReason(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -15,8 +24,8 @@ describe('ReferralReason', () => {
     })
 
     it('should return false with errors if the params are empty', async () => {
-      const body = {}
-      const step = new ReferralReason(body, {})
+      form.request.body = {}
+      const step = new ReferralReason(form)
 
       const valid = await step.valid()
 
@@ -26,11 +35,11 @@ describe('ReferralReason', () => {
     })
 
     it('should validate for the presence of `other` if the reason is `other`', async () => {
-      const body = {
+      form.request.body = {
         reason: 'other' as const,
       }
 
-      const step = new ReferralReason(body, {})
+      const step = new ReferralReason(form)
 
       const valid = await step.valid()
 
@@ -43,14 +52,18 @@ describe('ReferralReason', () => {
   describe('nextStep', () => {
     describe('with a referral reason', () => {
       it('it should return undefined when there is not `no-reason`', () => {
-        const step = new ReferralReason({ reason: 'likely' }, {})
+        form.request.body = { reason: 'likely' }
+
+        const step = new ReferralReason(form)
         const nextStep = step.nextStep()
 
         expect(nextStep).toEqual(undefined)
       })
 
       it('it should return `not-eligible` when there is `no-reason`', () => {
-        const step = new ReferralReason({ reason: 'no-reason' }, {})
+        form.request.body = { reason: 'no-reason' }
+
+        const step = new ReferralReason(form)
         const nextStep = step.nextStep()
 
         expect(nextStep).toEqual('not-eligible')
@@ -60,7 +73,7 @@ describe('ReferralReason', () => {
 
   describe('previousStep', () => {
     it('it should return undefined', () => {
-      const step = new ReferralReason({ reason: 'no-reason' }, {})
+      const step = new ReferralReason(form)
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual(undefined)
@@ -69,7 +82,7 @@ describe('ReferralReason', () => {
 
   describe('allowedToAccess', () => {
     it('it should return true', () => {
-      const step = new ReferralReason({ reason: 'no-reason' }, {})
+      const step = new ReferralReason(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)

--- a/server/forms/steps/room-searches.step.spec.ts
+++ b/server/forms/steps/room-searches.step.spec.ts
@@ -1,16 +1,25 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+
 import RoomSearches from './room-searches.step'
+import { ReferralApplication } from '../referral-application.form'
 
 describe('RoomSearches', () => {
+  let form: DeepMocked<ReferralApplication>
+
+  beforeEach(() => {
+    form = createMock<ReferralApplication>()
+  })
+
   describe('valid', () => {
     it('should return true with no errors if the params are valid', async () => {
-      const body = {
+      form.request.body = {
         items: ['radicalisation', 'hate-crime'],
         agencyRequest: 'yes',
         agency: 'some agency',
         supportingInformation: 'supporting',
       }
 
-      const step = new RoomSearches(body, {})
+      const step = new RoomSearches(form)
       const valid = await step.valid()
 
       expect(valid).toEqual(true)
@@ -18,8 +27,8 @@ describe('RoomSearches', () => {
     })
 
     it('should return false with errors if the params are empty', async () => {
-      const body = {}
-      const step = new RoomSearches(body, {})
+      form.request.body = {}
+      const step = new RoomSearches(form)
 
       const valid = await step.valid()
 
@@ -35,12 +44,12 @@ describe('RoomSearches', () => {
     })
 
     it('should return false with errors if agency request `yes` and agency is blank', async () => {
-      const body = {
+      form.request.body = {
         items: ['radicalisation', 'hate-crime'],
         agencyRequest: 'yes',
       }
 
-      const step = new RoomSearches(body, {})
+      const step = new RoomSearches(form)
 
       const valid = await step.valid()
 
@@ -55,7 +64,9 @@ describe('RoomSearches', () => {
 
   describe('nextStep', () => {
     it('should return CCTV if the CCTV option was previously selected', () => {
-      const step = new RoomSearches({}, { reasons: ['cctv'] })
+      form.sessionData = { reasons: ['cctv'] }
+
+      const step = new RoomSearches(form)
 
       const nextStep = step.nextStep()
 
@@ -63,7 +74,9 @@ describe('RoomSearches', () => {
     })
 
     it('should return CCTV if the CCTV option was not previously selected', () => {
-      const step = new RoomSearches({}, {})
+      form.sessionData = {}
+
+      const step = new RoomSearches(form)
 
       const nextStep = step.nextStep()
 
@@ -73,7 +86,10 @@ describe('RoomSearches', () => {
 
   describe('previousStep', () => {
     it('it should return undefined', () => {
-      const step = new RoomSearches({}, {})
+      form.sessionData = {}
+
+      const step = new RoomSearches(form)
+
       const previousStep = step.previousStep()
 
       expect(previousStep).toEqual('esap-reasons')
@@ -82,21 +98,27 @@ describe('RoomSearches', () => {
 
   describe('allowedToAccess', () => {
     it('it should return true if the secreting question was previously selected', () => {
-      const step = new RoomSearches({}, { reasons: ['secreting'] })
+      form.sessionData = { reasons: ['secreting'] }
+
+      const step = new RoomSearches(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(true)
     })
 
     it('it should return false if the secreting question was not previously selected', () => {
-      const step = new RoomSearches({}, { reasons: ['cctv'] })
+      form.sessionData = { reasons: ['cctv'] }
+
+      const step = new RoomSearches(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)
     })
 
     it('it should return false if the session is blank', () => {
-      const step = new RoomSearches({}, {})
+      form.sessionData = {}
+
+      const step = new RoomSearches(form)
       const allowedToAccess = step.allowedToAccess()
 
       expect(allowedToAccess).toEqual(false)

--- a/server/forms/steps/step.ts
+++ b/server/forms/steps/step.ts
@@ -1,7 +1,8 @@
 import { validate, ValidationError } from 'class-validator'
 
+import type { ReferralApplicationBody } from '../interfaces'
 import type { AllowedStepNames, AllowedSectionNames, Dto } from './index'
-import { ReferralApplicationBody } from '../interfaces'
+import type { ReferralApplication } from '../referral-application.form'
 
 interface ErrorMessages {
   [key: string]: Array<string>
@@ -12,9 +13,16 @@ export default abstract class Step {
 
   errorLength: number
 
-  abstract section: AllowedSectionNames
+  sessionData: ReferralApplicationBody
 
-  constructor(public readonly body: any, public readonly sessionData: ReferralApplicationBody) {}
+  body: any
+
+  constructor(public readonly form: ReferralApplication) {
+    this.sessionData = form.sessionData
+    this.body = form.request.body
+  }
+
+  abstract section: AllowedSectionNames
 
   abstract nextStep(): AllowedStepNames | undefined
 


### PR DESCRIPTION
This makes it easier for us to access everything within the form, as well as gives us a more predictable API