### PR TITLE
Define a simpler ReferralApplicationBody

### DIFF
--- a/server/forms/interfaces/index.ts
+++ b/server/forms/interfaces/index.ts
@@ -20,7 +20,9 @@ export type ReferralApplicationParams = {
   section: AllowedSectionNames
 }
 
-export type ReferralApplicationBody = Partial<ApType & ReferralReason & OpdPathway & EsapReasons>
+export interface ReferralApplicationBody {
+  [propName: string]: string | Array<string>
+}
 
 export type ReferralApplicationRequest = Request<
   ReferralApplicationParams,


### PR DESCRIPTION
We should find a way to type this more strongly, or at least filter out unexpected parameters, but this will at least fix the issue we have where the server won’t spin up