### PR TITLE
add postgis to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "nodenv"
 brew "postgresql" unless system "which -s psql"
+brew "postgis"
 brew "opensearch"


### PR DESCRIPTION
postgis is a dependency for the `script/setup` script that sets up the repo therefore we should install it via the `Brewfile`. 