### PR TITLE
Add typecheck to test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -14,6 +14,10 @@ echo "==> Waiting for Opensearch to become available..."
 
 script/utils/wait-for-opensearch.sh
 
+echo "==> Typechecking the code"
+
+npm run typecheck
+
 echo "==> Linting the code"
 
 npm run lint


### PR DESCRIPTION
Previously there was no typechecking in the `script/test` but there *was* (indirectly) in the `script/server` which meant type errors could pass the test script but fail the build script