### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   API_CLIENT_SECRET: clientsecret
   OPENSEARCH_URL: http://localhost:9200/
   OPENSEARCH_INDEX_NAME: bed_availability_test
+  DATABASE_SEED_FILE: ./data/ap_beds.csv
+  GEOLOCATION_SEED_FILE: ./data/ap_geolocations.csv
 
 jobs:
   test:
@@ -38,6 +40,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'npm'
+
+      - name: Load seed data
+        env:
+          APBEDS_DATA: ${{ secrets.APBEDS_DATA }}
+          APGEOLOCATION_DATA: ${{ secrets.APGEOLOCATION_DATA }}
+        run: |
+          mkdir -p data
+          echo $APBEDS_DATA | base64 -d | gzip -d > data/ap_beds.csv
+          echo $APGEOLOCATION_DATA | base64 -d | gzip -d > data/ap_geolocations.csv
 
       - name: Installing dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+env:
+  NODE_ENV: test
+  DATABASE_URL: postgres://postgres:password@localhost:5432/approved-premises-test
+  API_CLIENT_ID: approved-premises
+  API_CLIENT_SECRET: clientsecret
+  OPENSEARCH_URL: http://localhost:9200/
+  OPENSEARCH_INDEX_NAME: bed_availability_test
+
+jobs:
+  test:
+    services:
+      postgres:
+        image: postgis/postgis
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: approved-premises-test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'npm'
+
+      - name: Installing dependencies
+        run: npm install
+
+      - name: Building source
+        run: npm run build
+
+      - name: Run tests
+        id: test
+        run: script/test

--- a/doc/testing_in_ci.md
+++ b/doc/testing_in_ci.md
@@ -1,0 +1,22 @@
+# Testing in CI
+
+Tests are run in [Github Actions](https://github.com/ministryofjustice/approved-premises/actions)
+and setup is in [.github/workflows/ci.yml](https://github.com/ministryofjustice/approved-premises/blob/main/.github/workflows/ci.yml).
+
+The tests use the same script as running tests locally (`script/test`). The only difference is that the seed data for the placement search is loaded from
+environment variables which are base64 encoded and gzipped versions of the files
+referenced in `DATABASE_SEED_FILE` and `GEOLOCATION_SEED_FILE` locally.
+
+If you need to change this data for any reason, you can run the following locally:
+
+```bash
+cat path/to/file.csv | gzip -c | base64 | pbcopy
+```
+
+You will then have the Gzipped, base64 encoded version of the file copied to your
+clipboard. You can then update the appropriate environment variable in the
+[secrets section of the repo](https://github.com/ministryofjustice/approved-premises/settings/secrets/actions).
+
+This is similar to an approach suggested in the [Github Actions docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets#storing-base64-binary-blobs-as-secrets)
+with gzipping added to make the Base64 encoded string fit into the 64kb limit
+allowed for environment variables in Github Actions.

--- a/integration_tests/pages/placementSearch.ts
+++ b/integration_tests/pages/placementSearch.ts
@@ -1,4 +1,4 @@
-import Page from './page'
+import Page, { PageElement } from './page'
 
 export default class PlacementSearch extends Page {
   constructor() {


### PR DESCRIPTION
This runs our entire test suite in the CI (including unit and e2e tests). Some of the tests require data which is `.gitignore`d, as it could be considered sensitive. We store this data as base64 encoded and gzipped secrets, which we then unzip and decode as part of the CI process.