### PR TITLE
(342) Return users answers when returning to the questionnaire

### DIFF
--- a/integration_tests/integration/referral-application.spec.ts
+++ b/integration_tests/integration/referral-application.spec.ts
@@ -6,6 +6,7 @@ import TypeOfAP from '../pages/type-of-ap'
 import EsapReasons from '../pages/esap-reasons'
 import RoomSearches from '../pages/room-searches'
 import CCTV from '../pages/cctv'
+import CheckYourAnswers from '../pages/check-your-answers'
 
 context('SignIn', () => {
   beforeEach(() => {
@@ -76,6 +77,10 @@ context('SignIn', () => {
     cctv.answerCctvAgencyRequest('no')
     cctv.saveAndContinue()
 
+    const checkYourAnswers = Page.verifyOnPage(CheckYourAnswers)
+
+    checkYourAnswers.saveAndContinue()
+
     // And I should be returned to the tasklist
     Page.verifyOnPage(ReferralApplicationTasklist)
 
@@ -103,6 +108,9 @@ context('SignIn', () => {
     cctv.answerCctvAgencyRequest('no')
     cctv.saveAndContinue()
 
+    const checkYourAnswers = Page.verifyOnPage(CheckYourAnswers)
+    checkYourAnswers.saveAndContinue()
+
     Page.verifyOnPage(ReferralApplicationTasklist)
 
     // When the session is cleared
@@ -124,4 +132,8 @@ const checkEligibility = (page: ReferralApplicationTasklist) => {
 
   checkEligibilityPage.answerReason('likely')
   checkEligibilityPage.saveAndContinue()
+
+  const checkYourAnswers = Page.verifyOnPage(CheckYourAnswers)
+
+  checkYourAnswers.saveAndContinue()
 }

--- a/integration_tests/pages/check-your-answers.ts
+++ b/integration_tests/pages/check-your-answers.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class CheckYourAnswers extends Page {
+  constructor() {
+    super('Check your answers')
+  }
+}

--- a/server/controllers/referral-application.controller.spec.ts
+++ b/server/controllers/referral-application.controller.spec.ts
@@ -28,7 +28,7 @@ describe('ReferralApplicationController', () => {
       })
       const form = createMock<Form>({
         step: createMock<Step>({
-          questions: () => [questions],
+          questions: async () => [questions],
         }),
       })
 

--- a/server/controllers/referral-application.controller.spec.ts
+++ b/server/controllers/referral-application.controller.spec.ts
@@ -110,25 +110,5 @@ describe('ReferralApplicationController', () => {
         questions: ['QUESTION_HTML'],
       })
     })
-
-    it('should persist and complete the form and redirect to the tasklist if valid and there is no next step', async () => {
-      const persistDataSpy = jest.fn()
-      const completeSpy = jest.fn()
-
-      const form = createMock<Form>({
-        validForCurrentStep: () => true,
-        nextStep: (): undefined => undefined,
-        persistData: () => persistDataSpy(),
-        completeSection: () => completeSpy(),
-      })
-
-      jest.spyOn(Form, 'initialize').mockResolvedValue(form)
-
-      await ReferralApplicationController.update(request, response)
-
-      expect(response.redirect).toHaveBeenCalledWith('/referral_tasklist')
-      expect(persistDataSpy).toHaveBeenCalled()
-      expect(completeSpy).toHaveBeenCalled()
-    })
   })
 })

--- a/server/controllers/referral-application.controller.ts
+++ b/server/controllers/referral-application.controller.ts
@@ -5,7 +5,8 @@ import { OutOfSequenceError, UnknownStepError } from '../forms/errors'
 import { Form } from '../forms'
 
 const getQuestions = async (form: Form): Promise<Array<string>> => {
-  return Promise.all(form.step.questions().map(question => question.present()))
+  const questions = await form.step.questions()
+  return Promise.all(questions.map(question => question.present()))
 }
 
 export const ReferralApplicationController = {

--- a/server/controllers/referral-application.controller.ts
+++ b/server/controllers/referral-application.controller.ts
@@ -36,12 +36,7 @@ export const ReferralApplicationController = {
       await form.persistData()
       const nextStep = form.nextStep()
 
-      if (nextStep) {
-        res.redirect(`/referral-application/${form.step.section}/new/${nextStep}`)
-      } else {
-        form.completeSection()
-        res.redirect('/referral_tasklist')
-      }
+      res.redirect(`/referral-application/${form.step.section}/new/${nextStep}`)
     } else {
       const questions = await getQuestions(form)
 

--- a/server/controllers/referral-check-your-answers.controller.spec.ts
+++ b/server/controllers/referral-check-your-answers.controller.spec.ts
@@ -1,0 +1,74 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Response, Request } from 'express'
+
+import { ReferralCheckYourAnswersController } from './referral-check-your-answers.controller'
+
+import { Section, Form, Step } from '../forms'
+import { SummaryListItem } from '../forms/interfaces'
+
+jest.mock('../forms/form')
+jest.mock('../forms/section')
+
+describe('ReferralCheckYourAnswersController', () => {
+  describe('show', () => {
+    it('renders the template with section data and all steps', async () => {
+      const request = createMock<Request>({
+        params: { section: 'section' },
+      })
+      const response = createMock<Response>()
+
+      const step1Answers = [createMock<SummaryListItem>()]
+      const step2Answers = [createMock<SummaryListItem>(), createMock<SummaryListItem>()]
+
+      const mockSteps = [
+        createMock<Step>({ title: 'Step 1', answers: async () => step1Answers }),
+        createMock<Step>({
+          title: 'Step 2',
+          answers: async () => step2Answers,
+        }),
+        createMock<Step>({ title: 'Step 3', answers: async () => [] }),
+      ]
+      const mockSection = createMock<Section>({ allSteps: async () => mockSteps })
+      const next = jest.fn()
+
+      jest.spyOn(Section, 'initialize').mockResolvedValue(mockSection)
+
+      await ReferralCheckYourAnswersController.show(request, response, next)
+
+      const expectedSteps = [
+        {
+          title: mockSteps[0].title,
+          rows: step1Answers,
+        },
+        {
+          title: mockSteps[1].title,
+          rows: step2Answers,
+        },
+      ]
+
+      expect(Section.initialize).toHaveBeenCalledWith('section', request, Form.sessionVarName)
+      expect(response.render).toHaveBeenCalledWith(`referral-application/check-answers/show`, {
+        ...mockSection,
+        steps: expectedSteps,
+      })
+    })
+  })
+
+  describe('update', () => {
+    it('marks the section as complete and redirects to the tasklist', async () => {
+      const request = createMock<Request>()
+      const response = createMock<Response>()
+      const next = jest.fn()
+
+      const mockForm = createMock<Form>()
+      jest.spyOn(Form, 'initialize').mockResolvedValue(mockForm)
+
+      await ReferralCheckYourAnswersController.update(request, response, next)
+
+      expect(Form.initialize).toHaveBeenCalledWith(request)
+      expect(mockForm.completeSection).toHaveBeenCalled()
+
+      expect(response.redirect).toHaveBeenCalledWith('/referral_tasklist')
+    })
+  })
+})

--- a/server/controllers/referral-check-your-answers.controller.ts
+++ b/server/controllers/referral-check-your-answers.controller.ts
@@ -1,0 +1,30 @@
+import { Response, NextFunction, Request } from 'express'
+import { Form, Section } from '../forms'
+import type { AllowedSectionNames } from '../forms/interfaces'
+
+export const ReferralCheckYourAnswersController = {
+  show: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const section = await Section.initialize(req.params.section as AllowedSectionNames, req, Form.sessionVarName)
+    const steps = (
+      await Promise.all(
+        (
+          await section.allSteps()
+        ).map(async step => {
+          return {
+            title: step.title,
+            rows: await step.answers(),
+          }
+        })
+      )
+    ).filter(step => step.rows.length)
+
+    res.render('referral-application/check-answers/show', { ...section, steps })
+  },
+
+  update: async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const form = await Form.initialize(req)
+
+    form.completeSection()
+    res.redirect('/referral_tasklist')
+  },
+}

--- a/server/forms/form.spec.ts
+++ b/server/forms/form.spec.ts
@@ -4,7 +4,7 @@ import { pathExists, outputFile } from 'fs-extra'
 import { readFile } from 'fs/promises'
 import path from 'path'
 
-import { OutOfSequenceError, UnknownStepError } from './errors'
+import { OutOfSequenceError } from './errors'
 
 import Form from './form'
 import Section from './section'
@@ -37,8 +37,8 @@ describe('Form', () => {
       name: 'eligibility',
     })
 
-    jest.spyOn(Step, 'initialize').mockResolvedValue(mockStep)
     jest.spyOn(Section, 'initialize').mockResolvedValue(mockSection)
+    jest.spyOn(mockSection, 'getStep').mockResolvedValue(mockStep)
   })
 
   describe('initialize', () => {
@@ -49,12 +49,6 @@ describe('Form', () => {
       expect(async () => Form.initialize(request)).rejects.toThrowError(OutOfSequenceError)
     })
 
-    it('raises an error if the section does not match the step', async () => {
-      const request = createMock<Request>({})
-      mockSection.name = 'ap-type'
-
-      expect(async () => Form.initialize(request)).rejects.toThrowError(UnknownStepError)
-    })
     it('when called with a request with an empty body then it attempts to read the session from file', async () => {
       const pathExistsMock = (pathExists as jest.Mock).mockResolvedValue(true)
       const readFileMock = (readFile as jest.Mock).mockResolvedValue('{}')

--- a/server/forms/form.spec.ts
+++ b/server/forms/form.spec.ts
@@ -130,7 +130,7 @@ describe('Form', () => {
   })
 
   describe('nextStep', () => {
-    it('returns the next step from the session', async () => {
+    it('returns the next step from the step', async () => {
       mockStep.nextStep.mockReturnValue('some-step')
 
       const request = createMock<Request>({
@@ -144,6 +144,24 @@ describe('Form', () => {
       const form = await Form.initialize(request)
 
       expect(form.nextStep()).toEqual('some-step')
+
+      expect(mockStep.nextStep).toHaveBeenCalledWith(request.session[Form.sessionVarName])
+    })
+
+    it('returns check_your_answers if there is no next step', async () => {
+      mockStep.nextStep.mockReturnValue(undefined)
+
+      const request = createMock<Request>({
+        params: {
+          section: 'eligibility',
+          step: 'referral-reason',
+        },
+        body: {},
+      })
+
+      const form = await Form.initialize(request)
+
+      expect(form.nextStep()).toEqual('check_your_answers')
 
       expect(mockStep.nextStep).toHaveBeenCalledWith(request.session[Form.sessionVarName])
     })

--- a/server/forms/form.spec.ts
+++ b/server/forms/form.spec.ts
@@ -43,7 +43,7 @@ describe('Form', () => {
 
   describe('initialize', () => {
     it('raises an error if the step is not allowed', async () => {
-      const request = createMock<Request>({})
+      const request = createMock<Request>({ params: { step: 'some-step' } })
       mockStep.allowedToAccess.mockImplementation(() => false)
 
       expect(async () => Form.initialize(request)).rejects.toThrowError(OutOfSequenceError)
@@ -71,6 +71,14 @@ describe('Form', () => {
       await Form.initialize(request)
       expect(pathExistsMock).not.toHaveBeenCalled()
       expect(readFileMock).not.toHaveBeenCalled()
+    })
+
+    it('initializes the form without a step if there is not a step in the parameters', async () => {
+      const request = createMock<Request>({})
+
+      const form = await Form.initialize(request)
+
+      expect(form.step).toBeUndefined()
     })
   })
 

--- a/server/forms/form.ts
+++ b/server/forms/form.ts
@@ -18,7 +18,7 @@ export default class Form {
   sessionData = this.request.session[Form.sessionVarName]
 
   private constructor(readonly step: Step, readonly section: Section, readonly request: Request) {
-    if (this.step.allowedToAccess(this.sessionData) === false) {
+    if (this.step && this.step.allowedToAccess(this.sessionData) === false) {
       throw new OutOfSequenceError()
     }
   }
@@ -33,7 +33,7 @@ export default class Form {
       requestWithSavedSession,
       Form.sessionVarName
     )
-    const step = await section.getStep(request.params.step as AllowedStepNames)
+    const step = request.params.step ? await section.getStep(request.params.step as AllowedStepNames) : undefined
 
     return new Form(step, section, request)
   }

--- a/server/forms/form.ts
+++ b/server/forms/form.ts
@@ -53,7 +53,7 @@ export default class Form {
   }
 
   nextStep(): string {
-    return this.step.nextStep(this.request.session[Form.sessionVarName])
+    return this.step.nextStep(this.request.session[Form.sessionVarName]) || 'check_your_answers'
   }
 
   validForCurrentStep(): boolean {

--- a/server/forms/interfaces/index.ts
+++ b/server/forms/interfaces/index.ts
@@ -115,3 +115,21 @@ export interface InputItem {
 export interface Divider {
   divider: string
 }
+
+export type SummaryListActionItem = {
+  href: string
+  text: string
+  visuallyHiddenText: string
+}
+
+export type SummaryListItem = {
+  key: { text: string } | { html: string }
+  value: { text: string } | { html: string }
+  actions?: { items: Array<SummaryListActionItem> }
+}
+
+export type SummaryList = {
+  classes?: string
+  attributes?: any
+  rows: Array<SummaryListItem>
+}

--- a/server/forms/interfaces/index.ts
+++ b/server/forms/interfaces/index.ts
@@ -47,13 +47,15 @@ export interface ErrorMessages {
   [key: string]: Array<string>
 }
 
+export type RadioOrCheckBoxItems = Array<InputItem | Divider>
+
 export type RadioOptions = {
   idPrefix?: string
   name: string
   hint?: { html: string } | { text: string }
   fieldset?: FieldSetOptions
   errorMessage?: ErrorMessage
-  items?: Array<InputItem | Divider>
+  items?: RadioOrCheckBoxItems
 }
 
 export type TextAreaOptions = {
@@ -65,6 +67,17 @@ export type TextAreaOptions = {
 }
 
 export type CheckBoxOptions = RadioOptions
+
+export type DateInputItems = Array<DateInputItem>
+
+export type DateInputOptions = {
+  idPrefix?: string
+  name: string
+  hint?: { html: string } | { text: string }
+  fieldset?: FieldSetOptions
+  errorMessage?: ErrorMessage
+  items?: DateInputItems
+}
 
 export interface Label {
   text: string
@@ -83,6 +96,12 @@ export interface LegendOptions {
   text?: string
   isPageHeading?: boolean
   classes?: string
+}
+
+export interface DateInputItem {
+  classes?: string
+  name: string
+  value?: string
 }
 
 export interface InputItem {

--- a/server/forms/question.spec.ts
+++ b/server/forms/question.spec.ts
@@ -81,6 +81,18 @@ describe('Question', () => {
         expect(value).toEqual(undefined)
       })
     })
+
+    describe('key', () => {
+      it('returns the question text', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'type')
+
+        const key = question.key()
+
+        expect(key).toEqual('What type of AP does Robert Smith require?')
+      })
+    })
   })
 
   describe('with checkboxes', () => {
@@ -158,6 +170,18 @@ describe('Question', () => {
         expect(value).toEqual(undefined)
       })
     })
+
+    describe('key', () => {
+      it('returns the question text', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'cctv-reasons')
+
+        const key = question.key()
+
+        expect(key).toEqual('Which behaviours has Robert demonstrated that require enhanced CCTV provision to monitor?')
+      })
+    })
   })
 
   describe('with a textarea', () => {
@@ -206,6 +230,18 @@ describe('Question', () => {
         const value = question.value()
 
         expect(value).toEqual(undefined)
+      })
+    })
+
+    describe('key', () => {
+      it('returns the question text', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'cctv-supporting-information')
+
+        const key = question.key()
+
+        expect(key).toEqual('Provide any supporting information about why Robert requires enhanced CCTV provision.')
       })
     })
   })

--- a/server/forms/question.spec.ts
+++ b/server/forms/question.spec.ts
@@ -8,7 +8,7 @@ describe('Question', () => {
     it('renders a group of radio buttons', async () => {
       const step = createMock<Step>()
 
-      const question = new Question(step, 'type')
+      const question = await Question.initialize(step, 'type')
 
       const html = await question.present()
 
@@ -20,7 +20,7 @@ describe('Question', () => {
 
       step.body.type = 'standard'
 
-      const question = new Question(step, 'type')
+      const question = await Question.initialize(step, 'type')
 
       const html = await question.present()
 
@@ -36,7 +36,7 @@ describe('Question', () => {
         type: ['You must specify a type'],
       }
 
-      const question = new Question(step, 'type')
+      const question = await Question.initialize(step, 'type')
 
       const html = await question.present()
       expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a type')
@@ -46,7 +46,7 @@ describe('Question', () => {
       it('adds a conditional question', async () => {
         const step = createMock<Step>()
 
-        const question = new Question(step, 'is-opd-pathway-screened')
+        const question = await Question.initialize(step, 'is-opd-pathway-screened')
 
         const html = await question.present()
 
@@ -61,7 +61,7 @@ describe('Question', () => {
     it('renders a group of checkboxes', async () => {
       const step = createMock<Step>()
 
-      const question = new Question(step, 'cctv-reasons')
+      const question = await Question.initialize(step, 'cctv-reasons')
 
       const html = await question.present()
 
@@ -75,7 +75,7 @@ describe('Question', () => {
 
       step.body.cctvReasons = ['appearance', 'networks', 'community-threats']
 
-      const question = new Question(step, 'cctv-reasons')
+      const question = await Question.initialize(step, 'cctv-reasons')
 
       const html = await question.present()
 
@@ -99,7 +99,7 @@ describe('Question', () => {
         cctvReasons: ['You must specify a reason'],
       }
 
-      const question = new Question(step, 'cctv-reasons')
+      const question = await Question.initialize(step, 'cctv-reasons')
 
       const html = await question.present()
       expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a reason')
@@ -110,7 +110,7 @@ describe('Question', () => {
     it('returns a textarea', async () => {
       const step = createMock<Step>()
 
-      const question = new Question(step, 'cctv-supporting-information')
+      const question = await Question.initialize(step, 'cctv-supporting-information')
 
       const html = await question.present()
 
@@ -122,7 +122,7 @@ describe('Question', () => {
 
       step.body.cctvSupportingInformation = 'text goes here'
 
-      const question = new Question(step, 'cctv-supporting-information')
+      const question = await Question.initialize(step, 'cctv-supporting-information')
 
       const html = await question.present()
 

--- a/server/forms/question.spec.ts
+++ b/server/forms/question.spec.ts
@@ -184,6 +184,96 @@ describe('Question', () => {
     })
   })
 
+  describe('with a date input', () => {
+    describe('present', () => {
+      it('returns a date input', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const html = await question.present()
+
+        expect(html).toContain('When was Robert Brown&#39;s last consultation or formulation?')
+      })
+
+      it('prepopulates the question', async () => {
+        const step = createMock<Step>()
+
+        step.body['lastOpdDate-day'] = 22
+        step.body['lastOpdDate-month'] = 12
+        step.body['lastOpdDate-year'] = 2022
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const html = await question.present()
+
+        expect(html).toContain('name="lastOpdDate-day" type="text" value="22"')
+        expect(html).toContain('name="lastOpdDate-month" type="text" value="12"')
+        expect(html).toContain('name="lastOpdDate-year" type="text" value="2022"')
+      })
+
+      it('adds the error messages', async () => {
+        const step = createMock<Step>()
+
+        step.errorMessages = {
+          lastOpdDate: ['You must enter a valid date'],
+        }
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const html = await question.present()
+        expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must enter a valid date')
+        expect(html).toContain(
+          '<input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="lastOpdDate-day" name="lastOpdDate-day" type="text" pattern="[0-9]*" inputmode="numeric">'
+        )
+        expect(html).toContain(
+          '<input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" id="lastOpdDate-month" name="lastOpdDate-month" type="text" pattern="[0-9]*" inputmode="numeric">'
+        )
+        expect(html).toContain(
+          '<input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" id="lastOpdDate-year" name="lastOpdDate-year" type="text" pattern="[0-9]*" inputmode="numeric">'
+        )
+      })
+    })
+
+    describe('value', () => {
+      it('returns the response data', async () => {
+        const step = createMock<Step>()
+
+        step.body['lastOpdDate-day'] = 22
+        step.body['lastOpdDate-month'] = 12
+        step.body['lastOpdDate-year'] = 2022
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const value = question.value()
+
+        expect(value).toEqual('22 December 2022')
+      })
+
+      it('returns a blank response when there is no data', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const value = question.value()
+
+        expect(value).toEqual(undefined)
+      })
+    })
+
+    describe('key', () => {
+      it('returns the question text', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'last-opd-date')
+
+        const key = question.key()
+
+        expect(key).toEqual("When was Robert Brown's last consultation or formulation?")
+      })
+    })
+  })
+
   describe('with a textarea', () => {
     describe('present', () => {
       it('returns a textarea', async () => {

--- a/server/forms/question.spec.ts
+++ b/server/forms/question.spec.ts
@@ -5,128 +5,208 @@ import type Step from './step'
 
 describe('Question', () => {
   describe('with radio buttons', () => {
-    it('renders a group of radio buttons', async () => {
-      const step = createMock<Step>()
-
-      const question = await Question.initialize(step, 'type')
-
-      const html = await question.present()
-
-      expect(html).toContain('What type of AP does Robert Smith require?')
-    })
-
-    it('prepopulates an option if already selected', async () => {
-      const step = createMock<Step>()
-
-      step.body.type = 'standard'
-
-      const question = await Question.initialize(step, 'type')
-
-      const html = await question.present()
-
-      expect(html).toContain(
-        '<input class="govuk-radios__input" id="type" name="type" type="radio" value="standard" checked>'
-      )
-    })
-
-    it('adds the error messages to the group', async () => {
-      const step = createMock<Step>()
-
-      step.errorMessages = {
-        type: ['You must specify a type'],
-      }
-
-      const question = await Question.initialize(step, 'type')
-
-      const html = await question.present()
-      expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a type')
-    })
-
-    describe('when there are conditional questions', () => {
-      it('adds a conditional question', async () => {
+    describe('present', () => {
+      it('renders a group of radio buttons', async () => {
         const step = createMock<Step>()
 
-        const question = await Question.initialize(step, 'is-opd-pathway-screened')
+        const question = await Question.initialize(step, 'type')
 
         const html = await question.present()
 
-        expect(html).toContain('Has Robert Brown been screened into the OPD pathway?')
-        expect(html).toContain('govuk-radios__conditional govuk-radios__conditional--hidden')
-        expect(html).toContain('When was Robert Brown&#39;s last consultation or formulation?')
+        expect(html).toContain('What type of AP does Robert Smith require?')
+      })
+
+      it('prepopulates an option if already selected', async () => {
+        const step = createMock<Step>()
+
+        step.body.type = 'standard'
+
+        const question = await Question.initialize(step, 'type')
+
+        const html = await question.present()
+
+        expect(html).toContain(
+          '<input class="govuk-radios__input" id="type" name="type" type="radio" value="standard" checked>'
+        )
+      })
+
+      it('adds the error messages to the group', async () => {
+        const step = createMock<Step>()
+
+        step.errorMessages = {
+          type: ['You must specify a type'],
+        }
+
+        const question = await Question.initialize(step, 'type')
+
+        const html = await question.present()
+        expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a type')
+      })
+
+      describe('when there are conditional questions', () => {
+        it('adds a conditional question', async () => {
+          const step = createMock<Step>()
+
+          const question = await Question.initialize(step, 'is-opd-pathway-screened')
+
+          const html = await question.present()
+
+          expect(html).toContain('Has Robert Brown been screened into the OPD pathway?')
+          expect(html).toContain('govuk-radios__conditional govuk-radios__conditional--hidden')
+          expect(html).toContain('When was Robert Brown&#39;s last consultation or formulation?')
+        })
+      })
+    })
+
+    describe('value', () => {
+      it('returns the response data', async () => {
+        const step = createMock<Step>()
+
+        step.body.type = 'standard'
+
+        const question = await Question.initialize(step, 'type')
+
+        const value = question.value()
+
+        expect(value).toEqual('Standard')
+      })
+
+      it('returns a blank response when there is no data', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'type')
+
+        const value = question.value()
+
+        expect(value).toEqual(undefined)
       })
     })
   })
 
   describe('with checkboxes', () => {
-    it('renders a group of checkboxes', async () => {
-      const step = createMock<Step>()
+    describe('present', () => {
+      it('renders a group of checkboxes', async () => {
+        const step = createMock<Step>()
 
-      const question = await Question.initialize(step, 'cctv-reasons')
+        const question = await Question.initialize(step, 'cctv-reasons')
 
-      const html = await question.present()
+        const html = await question.present()
 
-      expect(html).toContain(
-        'Which behaviours has Robert demonstrated that require enhanced CCTV provision to monitor?'
-      )
+        expect(html).toContain(
+          'Which behaviours has Robert demonstrated that require enhanced CCTV provision to monitor?'
+        )
+      })
+
+      it('prepopulates an option if already selected', async () => {
+        const step = createMock<Step>()
+
+        step.body.cctvReasons = ['appearance', 'networks', 'community-threats']
+
+        const question = await Question.initialize(step, 'cctv-reasons')
+
+        const html = await question.present()
+
+        expect(html).toContain(
+          '<input class="govuk-checkboxes__input" id="cctvReasons" name="cctvReasons[]" type="checkbox" value="appearance" checked>'
+        )
+
+        expect(html).toContain(
+          '<input class="govuk-checkboxes__input" id="cctvReasons-2" name="cctvReasons[]" type="checkbox" value="networks" checked>'
+        )
+
+        expect(html).toContain(
+          '<input class="govuk-checkboxes__input" id="cctvReasons-6" name="cctvReasons[]" type="checkbox" value="community-threats" checked>'
+        )
+      })
+
+      it('adds the error messages to the group', async () => {
+        const step = createMock<Step>()
+
+        step.errorMessages = {
+          cctvReasons: ['You must specify a reason'],
+        }
+
+        const question = await Question.initialize(step, 'cctv-reasons')
+
+        const html = await question.present()
+        expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a reason')
+      })
     })
 
-    it('prepopulates an option if already selected', async () => {
-      const step = createMock<Step>()
+    describe('value', () => {
+      it('returns the response data', async () => {
+        const step = createMock<Step>()
 
-      step.body.cctvReasons = ['appearance', 'networks', 'community-threats']
+        step.body.cctvReasons = ['appearance', 'networks', 'community-threats']
 
-      const question = await Question.initialize(step, 'cctv-reasons')
+        const question = await Question.initialize(step, 'cctv-reasons')
 
-      const html = await question.present()
+        const value = question.value()
 
-      expect(html).toContain(
-        '<input class="govuk-checkboxes__input" id="cctvReasons" name="cctvReasons[]" type="checkbox" value="appearance" checked>'
-      )
+        expect(value).toEqual(
+          'Changed their appearance or clothing to offend<br>Built networks within offender groups<br>Experienced threats from the local community or media intrusion that poses a risk to the individual, other residents or staff'
+        )
+      })
 
-      expect(html).toContain(
-        '<input class="govuk-checkboxes__input" id="cctvReasons-2" name="cctvReasons[]" type="checkbox" value="networks" checked>'
-      )
+      it('returns a blank response when there is no data', async () => {
+        const step = createMock<Step>()
 
-      expect(html).toContain(
-        '<input class="govuk-checkboxes__input" id="cctvReasons-6" name="cctvReasons[]" type="checkbox" value="community-threats" checked>'
-      )
-    })
+        const question = await Question.initialize(step, 'cctv-reasons')
 
-    it('adds the error messages to the group', async () => {
-      const step = createMock<Step>()
+        const value = question.value()
 
-      step.errorMessages = {
-        cctvReasons: ['You must specify a reason'],
-      }
-
-      const question = await Question.initialize(step, 'cctv-reasons')
-
-      const html = await question.present()
-      expect(html).toContain('<span class="govuk-visually-hidden">Error:</span> You must specify a reason')
+        expect(value).toEqual(undefined)
+      })
     })
   })
 
   describe('with a textarea', () => {
-    it('returns a textarea', async () => {
-      const step = createMock<Step>()
+    describe('present', () => {
+      it('returns a textarea', async () => {
+        const step = createMock<Step>()
 
-      const question = await Question.initialize(step, 'cctv-supporting-information')
+        const question = await Question.initialize(step, 'cctv-supporting-information')
 
-      const html = await question.present()
+        const html = await question.present()
 
-      expect(html).toContain('Provide any supporting information about why Robert requires enhanced CCTV provision.')
+        expect(html).toContain('Provide any supporting information about why Robert requires enhanced CCTV provision.')
+      })
+
+      it('prepopulates the question', async () => {
+        const step = createMock<Step>()
+
+        step.body.cctvSupportingInformation = 'text goes here'
+
+        const question = await Question.initialize(step, 'cctv-supporting-information')
+
+        const html = await question.present()
+
+        expect(html).toContain('text goes here')
+      })
     })
 
-    it('prepopulates the question', async () => {
-      const step = createMock<Step>()
+    describe('value', () => {
+      it('returns the response data', async () => {
+        const step = createMock<Step>()
 
-      step.body.cctvSupportingInformation = 'text goes here'
+        step.body.cctvSupportingInformation = 'text goes here'
 
-      const question = await Question.initialize(step, 'cctv-supporting-information')
+        const question = await Question.initialize(step, 'cctv-supporting-information')
 
-      const html = await question.present()
+        const value = question.value()
 
-      expect(html).toContain('text goes here')
+        expect(value).toEqual('text goes here')
+      })
+
+      it('returns a blank response when there is no data', async () => {
+        const step = createMock<Step>()
+
+        const question = await Question.initialize(step, 'cctv-supporting-information')
+
+        const value = question.value()
+
+        expect(value).toEqual(undefined)
+      })
     })
   })
 })

--- a/server/forms/question.ts
+++ b/server/forms/question.ts
@@ -94,6 +94,14 @@ export default class Question {
     )
   }
 
+  public key(): string {
+    if ('label' in this.args) {
+      return this.args.label.text
+    }
+
+    return this.args.fieldset.legend.text
+  }
+
   public value(): string {
     const fieldValue = this.body[this.fieldName]
 

--- a/server/forms/question.ts
+++ b/server/forms/question.ts
@@ -94,6 +94,26 @@ export default class Question {
     )
   }
 
+  public value(): string {
+    const fieldValue = this.body[this.fieldName]
+
+    if ('items' in this.args) {
+      // If this question is a checkbox group with multiple answers
+      if (Array.isArray(fieldValue)) {
+        const items = this.args.items.filter(i => 'value' in i && fieldValue.includes(i.value))
+        return items.map(i => 'text' in i && i.text).join('<br>')
+      }
+
+      // If this question is a group of radio buttons
+      const item = this.args.items.find(i => 'value' in i && i.value === fieldValue)
+      if (item && 'text' in item) {
+        return item.text
+      }
+    }
+
+    return fieldValue
+  }
+
   private isChecked(key: string, value: string): boolean {
     const fieldValue = this.body[key]
 

--- a/server/forms/section.spec.ts
+++ b/server/forms/section.spec.ts
@@ -215,4 +215,23 @@ describe('Section', () => {
       expect(stepSpy).not.toHaveBeenCalled()
     })
   })
+
+  describe('allSteps', () => {
+    it('should return all steps', async () => {
+      sectionDataMock.steps = ['referral-reason', 'not-eligible']
+      jest.spyOn(fsPromises, 'readFile').mockResolvedValueOnce(JSON.stringify(sectionDataMock))
+
+      const request = createMock<Request>({})
+      const stepSpy = jest.spyOn(Step, 'initialize')
+
+      const section = await Section.initialize('eligibility', request, 'referralApplication')
+
+      const allSteps = await section.allSteps()
+
+      expect(allSteps.length).toEqual(2)
+
+      expect(stepSpy).toHaveBeenCalledWith('referral-reason', request)
+      expect(stepSpy).toHaveBeenCalledWith('not-eligible', request)
+    })
+  })
 })

--- a/server/forms/section.spec.ts
+++ b/server/forms/section.spec.ts
@@ -196,13 +196,46 @@ describe('Section', () => {
     })
 
     it('should return a step object when it exists in a section', async () => {
-      const request = createMock<Request>({})
+      const body = { foo: 'bar' } as any
+      const request = createMock<Request>({
+        body,
+      })
 
       const section = await Section.initialize('eligibility', request, 'referralApplication')
 
       await section.getStep('referral-reason')
 
-      expect(stepSpy).toHaveBeenCalledWith('referral-reason', request)
+      expect(stepSpy).toHaveBeenCalledWith('referral-reason', body)
+    })
+
+    it('should send the session data as the body when the request body does not exist', async () => {
+      const body = {} as any
+      const session = { referralApplication: { foo: 'bar' } } as any
+      const request = createMock<Request>({
+        body,
+        session,
+      })
+
+      const section = await Section.initialize('eligibility', request, 'referralApplication')
+
+      await section.getStep('referral-reason')
+
+      expect(stepSpy).toHaveBeenCalledWith('referral-reason', session.referralApplication)
+    })
+
+    it('should send an empty object as the body when the request body does not exist', async () => {
+      const body = {} as any
+      const session = {} as any
+      const request = createMock<Request>({
+        body,
+        session,
+      })
+
+      const section = await Section.initialize('eligibility', request, 'referralApplication')
+
+      await section.getStep('referral-reason')
+
+      expect(stepSpy).toHaveBeenCalledWith('referral-reason', {})
     })
 
     it('should raise an error when the section does not exist', async () => {

--- a/server/forms/section.spec.ts
+++ b/server/forms/section.spec.ts
@@ -9,6 +9,7 @@ const sectionDataMock = {
   name: 'eligibility',
   previousSection: null,
   nextSection: 'ap-type',
+  steps: ['referral-reason', 'not-eligible'],
 } as unknown as SectionData
 
 jest.mock('fs/promises', () => {
@@ -38,6 +39,7 @@ describe('Section', () => {
       expect(section.name).toEqual('eligibility')
       expect(section.previousSection).toEqual(null)
       expect(section.nextSection).toEqual('ap-type')
+      expect(section.steps).toEqual(['referral-reason', 'not-eligible'])
     })
   })
 

--- a/server/forms/section.ts
+++ b/server/forms/section.ts
@@ -3,6 +3,9 @@ import { readFile } from 'fs/promises'
 
 import { retrieveSavedSession } from './helpers/retrieveSavedSession'
 import type { AllowedSectionNames, AllowedStepNames } from './interfaces'
+import { UnknownStepError } from './errors'
+
+import Step from './step'
 
 export interface SectionData {
   name: string
@@ -34,6 +37,14 @@ export default class Section {
 
   public complete(): void {
     this.setSectionStatus('complete')
+  }
+
+  public async getStep(stepName: AllowedStepNames): Promise<Step> {
+    if (!this.steps.includes(stepName)) {
+      throw new UnknownStepError()
+    }
+
+    return Step.initialize(stepName, this.request.body)
   }
 
   public async status(): Promise<string> {

--- a/server/forms/section.ts
+++ b/server/forms/section.ts
@@ -2,12 +2,13 @@ import { Request } from 'express'
 import { readFile } from 'fs/promises'
 
 import { retrieveSavedSession } from './helpers/retrieveSavedSession'
-import type { AllowedSectionNames } from './interfaces'
+import type { AllowedSectionNames, AllowedStepNames } from './interfaces'
 
 export interface SectionData {
   name: string
   previousSection: AllowedSectionNames
   nextSection: AllowedSectionNames
+  steps: Array<AllowedStepNames>
 }
 
 export default class Section {
@@ -16,6 +17,8 @@ export default class Section {
   previousSection: AllowedSectionNames = this.sectionData.previousSection
 
   nextSection: AllowedSectionNames = this.sectionData.nextSection
+
+  steps: Array<AllowedStepNames> = this.sectionData.steps
 
   private constructor(
     readonly sectionData: SectionData,

--- a/server/forms/section.ts
+++ b/server/forms/section.ts
@@ -47,6 +47,10 @@ export default class Section {
     return Step.initialize(stepName, this.request.body)
   }
 
+  public async allSteps(): Promise<Step[]> {
+    return Promise.all(this.steps.map(step => this.getStep(step)))
+  }
+
   public async status(): Promise<string> {
     const sessionVar = this.request.session?.[this.sessionVarName]?.sections?.[this.name]
 

--- a/server/forms/section.ts
+++ b/server/forms/section.ts
@@ -44,7 +44,10 @@ export default class Section {
       throw new UnknownStepError()
     }
 
-    return Step.initialize(stepName, this.request.body)
+    const body =
+      Object.keys(this.request.body).length > 0 ? this.request.body : this.request.session[this.sessionVarName] || {}
+
+    return Step.initialize(stepName, body)
   }
 
   public async allSteps(): Promise<Step[]> {

--- a/server/forms/sections/ap-type.json
+++ b/server/forms/sections/ap-type.json
@@ -1,5 +1,6 @@
 {
   "name": "ap-type",
   "previousSection": "eligibility",
-  "nextSection": null
+  "nextSection": null,
+  "steps": ["type-of-ap", "opd-pathway", "esap-reasons", "room-searches", "cctv"]
 }

--- a/server/forms/sections/eligibility.json
+++ b/server/forms/sections/eligibility.json
@@ -1,5 +1,6 @@
 {
   "name": "eligibility",
   "previousSection": null,
-  "nextSection": "ap-type"
+  "nextSection": "ap-type",
+  "steps": ["referral-reason", "not-eligible"]
 }

--- a/server/forms/step.spec.ts
+++ b/server/forms/step.spec.ts
@@ -21,6 +21,8 @@ jest.mock('fs/promises', () => {
   }
 })
 
+jest.mock('./question')
+
 describe('Step', () => {
   let step: Step
 
@@ -249,13 +251,16 @@ describe('Step', () => {
     it('should return an array of questions', async () => {
       stepMock.questions = ['question1', 'question2']
 
+      const questionSpy = jest.spyOn(Question, 'initialize')
+
       step = await Step.initialize('step', {})
-      const questions = step.questions()
+      const questions = await step.questions()
 
       expect(questions.length).toEqual(2)
 
-      expect(questions[0]).toBeInstanceOf(Question)
-      expect(questions[1]).toBeInstanceOf(Question)
+      expect(questionSpy).toHaveBeenCalledTimes(2)
+      expect(questionSpy).toHaveBeenCalledWith(step, stepMock.questions[0])
+      expect(questionSpy).toHaveBeenCalledWith(step, stepMock.questions[1])
     })
   })
 })

--- a/server/forms/step.spec.ts
+++ b/server/forms/step.spec.ts
@@ -1,4 +1,5 @@
 import fsPromises from 'fs/promises'
+import { createMock } from '@golevelup/ts-jest'
 
 import Step from './step'
 import Question from './question'
@@ -261,6 +262,79 @@ describe('Step', () => {
       expect(questionSpy).toHaveBeenCalledTimes(2)
       expect(questionSpy).toHaveBeenCalledWith(step, stepMock.questions[0])
       expect(questionSpy).toHaveBeenCalledWith(step, stepMock.questions[1])
+    })
+  })
+
+  describe('answers', () => {
+    it('should return answers', async () => {
+      stepMock.questions = ['question1', 'question2']
+      const question1 = createMock<Question>({
+        key: () => 'Question 1',
+        value: () => 'Value 1',
+      })
+      const question2 = createMock<Question>({
+        key: () => 'Question 2',
+        value: () => 'Value 2',
+      })
+
+      jest.spyOn(Question, 'initialize').mockImplementation(async (_step: Step, question: string) => {
+        if (question === 'question1') {
+          return question1
+        }
+        return question2
+      })
+
+      step = await Step.initialize('step', {})
+      const answers = await step.answers()
+
+      expect(answers).toEqual([
+        {
+          actions: {
+            items: [{ href: '/referral-application/bar/new/foo', text: 'Change', visuallyHiddenText: 'Question 1' }],
+          },
+          key: { text: 'Question 1' },
+          value: { html: 'Value 1' },
+        },
+        {
+          actions: {
+            items: [{ href: '/referral-application/bar/new/foo', text: 'Change', visuallyHiddenText: 'Question 2' }],
+          },
+          key: { text: 'Question 2' },
+          value: { html: 'Value 2' },
+        },
+      ])
+    })
+
+    it('should hide unanswered questions', async () => {
+      stepMock.questions = ['question1', 'question2']
+      const question1 = createMock<Question>({
+        key: () => 'Question 1',
+        value: () => 'Value 1',
+      })
+      const question2 = createMock<Question>({
+        key: () => 'Question 2',
+        value: () => undefined,
+      })
+
+      jest.spyOn(Question, 'initialize').mockImplementation(async (_step: Step, question: string) => {
+        if (question === 'question1') {
+          return question1
+        }
+        return question2
+      })
+
+      step = await Step.initialize('step', {})
+      const answers = await step.answers()
+
+      expect(answers).toEqual([
+        {
+          actions: {
+            items: [{ href: '/referral-application/bar/new/foo', text: 'Change', visuallyHiddenText: 'Question 1' }],
+          },
+          key: { text: 'Question 1' },
+          value: { html: 'Value 1' },
+        },
+      ])
     })
   })
 })

--- a/server/forms/step.ts
+++ b/server/forms/step.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 
 import { jsonLogic, RulesLogic } from './utils/jsonlogic'
-import { StepDefinition, ErrorMessages } from './interfaces'
+import { StepDefinition, ErrorMessages, SummaryListItem } from './interfaces'
 import Question from './question'
 
 export default class Step {
@@ -53,7 +53,7 @@ export default class Step {
     return rule
   }
 
-  public async answers() {
+  public async answers(): Promise<Array<SummaryListItem>> {
     const questions = await this.questions()
     return questions
       .map(question => {

--- a/server/forms/step.ts
+++ b/server/forms/step.ts
@@ -39,8 +39,8 @@ export default class Step {
     return Object.keys(this.errorMessages).length === 0
   }
 
-  public questions(): Array<Question> {
-    return this.step.questions.map(question => new Question(this, question))
+  public async questions(): Promise<Array<Question>> {
+    return Promise.all(this.step.questions.map(async question => Question.initialize(this, question)))
   }
 
   public allowedToAccess(data: any) {

--- a/server/forms/step.ts
+++ b/server/forms/step.ts
@@ -53,6 +53,31 @@ export default class Step {
     return rule
   }
 
+  public async answers() {
+    const questions = await this.questions()
+    return questions
+      .map(question => {
+        return {
+          key: {
+            text: question.key(),
+          },
+          value: {
+            html: question.value(),
+          },
+          actions: {
+            items: [
+              {
+                href: `/referral-application/${this.section}/new/${this.name}`,
+                text: 'Change',
+                visuallyHiddenText: question.key(),
+              },
+            ],
+          },
+        }
+      })
+      .filter(item => item.value.html)
+  }
+
   private validate(): void {
     const errors = {}
 

--- a/server/routes/referralApplicationRoutes.ts
+++ b/server/routes/referralApplicationRoutes.ts
@@ -2,10 +2,14 @@ import { Router } from 'express'
 import { ReferralApplicationParams, ReferralApplicationBody } from '../forms/interfaces'
 
 import { ReferralApplicationController } from '../controllers/referral-application.controller'
+import { ReferralCheckYourAnswersController } from '../controllers/referral-check-your-answers.controller'
 
 export const referralApplicationPrefix = '/referral-application'
 
 export function ReferralApplicationRoutes(router: Router): Router {
+  router.get<ReferralApplicationParams>('/:section/new/check_your_answers', ReferralCheckYourAnswersController.show)
+  router.post<ReferralApplicationParams>('/:section/check_your_answers', ReferralCheckYourAnswersController.update)
+
   router.get<ReferralApplicationParams>('/:section/new/:step', ReferralApplicationController.show)
   router.post<ReferralApplicationParams, Record<string, unknown>, ReferralApplicationBody>(
     '/:section/:step',

--- a/server/views/referral-application/check-answers/show.njk
+++ b/server/views/referral-application/check-answers/show.njk
@@ -1,0 +1,33 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = applicationName + " - " + step.title %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds-from-desktop">
+			<h1 class="govuk-heading-l">Check your answers</h1>
+
+			{% for step in steps %}
+				<h2 class="govuk-heading-m">{{ step.title }}</h2>
+
+				{{
+						govukSummaryList({
+							classes: 'govuk-!-margin-bottom-9',
+        			rows: step.rows
+						})
+					}}
+			{% endfor %}
+
+			<form method="post" action="/referral-application/{{ name }}/check_your_answers">
+				<input type="hidden" name="_csrf" value={{csrfToken}}>
+
+				{{ govukButton({
+            text: "Save and continue"
+          }) }}
+			</form>
+		</div>
+	</div>
+{% endblock %}


### PR DESCRIPTION
This adds a Check Your Answers page to the end of each section in the referral questionnaire. It's required a few tweaks to the plumbing, but I think we're overall in a better place. I could have improved the e2e tests to check the responses show in the CYA page, but this can come later

## Screenshots of UI changes
 
![image](https://user-images.githubusercontent.com/109774/176184310-6fbcc7eb-237f-4fdd-abb0-a5018ed94503.png)
